### PR TITLE
fix: use `~` as delimiter for strike through texts

### DIFF
--- a/__tests__/html-to-mrkdwn.spec.ts
+++ b/__tests__/html-to-mrkdwn.spec.ts
@@ -1,0 +1,21 @@
+import htmlToMrkdwn from '../src/index'
+
+describe('Transform HTML to Slack mrdkwn', () => {
+  it('When HTML text contains strikethrough', () => {
+    const html = `<div><s>Strikethrough Text</s></div>`
+    const actual = htmlToMrkdwn(html)
+    expect(actual).toEqual({
+      image: '',
+      text: '~Strikethrough Text~'
+    })
+  })
+
+  it('When HTML text contains Bold', () => {
+    const html = `<div><strong>Bold Text</strong></div>`
+    const actual = htmlToMrkdwn(html)
+    expect(actual).toEqual({
+      image: '',
+      text: '*Bold Text*'
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "node-html-markdown": "^1.1.3"
+    "node-html-markdown": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "html-to-mrkdwn-ts",
+  "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/oferitz/html-to-mrkdwn-ts.git"
+    "url": "git+https://github.com/clearfeed/html-to-mrkdwn-ts.git"
   },
   "bugs": {
-    "url": "https://github.com/oferitz/html-to-mrkdwn-ts/issues"
+    "url": "https://github.com/clearfeed/html-to-mrkdwn-ts/issues"
   },
-  "homepage": "https://github.com/oferitz/html-to-mrkdwn-ts#readme",
+  "homepage": "https://github.com/clearfeed/html-to-mrkdwn-ts#readme",
   "engines": {
     "node": ">=14.0.0"
   },
@@ -27,7 +27,7 @@
     "slack",
     "mrkdwn"
   ],
-  "author": "Ofer Itzhaki",
+  "author": "ClearFeed",
   "scripts": {
     "run": "ts-node ./src/index.ts",
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,26 @@ import translators from './translators'
 import { findFirstImageSrc } from './utils'
 
 const baseOptions: Partial<NodeHtmlMarkdownOptions> = {
+  /**
+   * Marker used by Slack mrkdwn for bullet lists.
+   */
+  bulletMarker: '•',
+  /**
+   * In Slack mrkdwn: {@link https://api.slack.com/reference/surfaces/formatting#basics}
+   * - Bold text is represented by a single asterisk (*),
+   *   deviating from the standard double asterisks (**) used in regular Markdown.
+   * - Strikethrough is denoted by a single tilde (~),
+   *   in contrast to the standard double tilde (~~) used in regular Markdown.
+   */
+
   strongDelimiter: '*',
+  strikeDelimiter: '~',
   globalEscape: [] as any,
   lineStartEscape: [] as any
 }
 
-const htmlToMrkdwn = (html: string, options = baseOptions) => {
-  const result = NodeHtmlMarkdown.translate(html, options, translators)
+const htmlToMrkdwn = (html: string, options: Partial<NodeHtmlMarkdownOptions> = {}) => {
+  const result = NodeHtmlMarkdown.translate(html, { ...baseOptions, ...options }, translators)
   return {
     text: result,
     image: findFirstImageSrc(html)

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const baseOptions: Partial<NodeHtmlMarkdownOptions> = {
 }
 
 const htmlToMrkdwn = (html: string, options: Partial<NodeHtmlMarkdownOptions> = {}) => {
-  const result = NodeHtmlMarkdown.translate(html, { ...baseOptions, ...options }, translators)
+  const result = NodeHtmlMarkdown.translate(html, Object.assign(baseOptions, options), translators)
   return {
     text: result,
     image: findFirstImageSrc(html)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,21 +1182,21 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-select@^4.1.3:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.2.0.tgz#ab28276d3afb00cc05e818bd33eb030f14f57895"
-  integrity sha512-6YVG6hsH9yIb/si3Th/is8Pex7qnVHO6t7q7U6TIUnkQASGbS8tnUDBftnPynLNnuUl/r2+PTd0ekiiq7R0zJw==
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
   dependencies:
     boolbase "^1.0.0"
-    css-what "^5.1.0"
-    domhandler "^4.3.0"
-    domutils "^2.8.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
     nth-check "^2.0.1"
 
-css-what@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
-  integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 debug@^4.1.0, debug@^4.1.1:
   version "4.3.3"
@@ -1230,35 +1230,35 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-dom-serializer@^1.0.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
-  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
   dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^4.2.0"
-    entities "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
 
-domelementtype@^2.0.1, domelementtype@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
-  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
-domhandler@^4.2.0, domhandler@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.0.tgz#16c658c626cf966967e306f966b431f77d4a5626"
-  integrity sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
-    domelementtype "^2.2.0"
+    domelementtype "^2.3.0"
 
-domutils@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
-  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+domutils@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
   dependencies:
-    dom-serializer "^1.0.1"
-    domelementtype "^2.2.0"
-    domhandler "^4.2.0"
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 electron-to-chromium@^1.4.17:
   version "1.4.26"
@@ -1280,10 +1280,10 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-entities@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
-  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -2041,7 +2041,7 @@ mimic-fn@^2.1.0:
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 minimatch@^3.0.4:
-  version "3.1.2"
+  version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
@@ -2057,19 +2057,19 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-node-html-markdown@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/node-html-markdown/-/node-html-markdown-1.1.3.tgz#355e09b1d2624755a258404cb17219d49e6dd18d"
-  integrity sha512-iB5Nb8eQjeKHr1k9ot0FkVo5uah6IvYzSbOiNPbmtMt8OWf8os9TCsGEg1Xf51xwYLW461AvKl74HVjiMxvblg==
+node-html-markdown@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/node-html-markdown/-/node-html-markdown-1.3.0.tgz#ef0b19a3bbfc0f1a880abb9ff2a0c9aa6bbff2a9"
+  integrity sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==
   dependencies:
-    node-html-parser "^4.1.5"
+    node-html-parser "^6.1.1"
 
-node-html-parser@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-4.1.5.tgz#e3ff5b39a098e70de3629c9c79c4e29a3fa5f062"
-  integrity sha512-NLgqUXtftqnBqIjlRjYSaApaqE7TTxfTiH4VqKCjdUJKFOtUzRwney83EHz2qYc0XoxXAkYdmLjENCuZHvsIFg==
+node-html-parser@^6.1.1:
+  version "6.1.12"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.12.tgz#6138f805d0ad7a6b5ef415bcd91bca07374bf575"
+  integrity sha512-/bT/Ncmv+fbMGX96XG9g05vFt43m/+SYKIs9oAemQVYyVcZmDAI2Xq/SbNcpOA35eF0Zk2av3Ksf+Xk8Vt8abA==
   dependencies:
-    css-select "^4.1.3"
+    css-select "^5.1.0"
     he "1.2.0"
 
 node-int64@^0.4.0:


### PR DESCRIPTION
The default strikethrough delimiter for regular Markdown is `~`. But this doesn't work with the default slack mrkdwn. 
So in this pr
1. Switched to using sing tilde `~` as the default delimiter.