### PR TITLE
fix: spread options instead of using Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const baseOptions: Partial<NodeHtmlMarkdownOptions> = {
 }
 
 const htmlToMrkdwn = (html: string, options: Partial<NodeHtmlMarkdownOptions> = {}) => {
-  const result = NodeHtmlMarkdown.translate(html, Object.assign(baseOptions, options), translators)
+  const result = NodeHtmlMarkdown.translate(html, { ...baseOptions, ...options }, translators)
   return {
     text: result,
     image: findFirstImageSrc(html)


### PR DESCRIPTION
On doing Object.assign, the global base options are getting updated, so if we pass some parameter once to the function, the same options are being used for other function calls as well.


Ran the test cases, they are all passing

![image](https://github.com/user-attachments/assets/ba01f803-36b1-416f-bb7b-b8dfbe4ffbf9)
