### PR TITLE
APP-5369: reduce newlines around para to 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/src/translators.ts
+++ b/src/translators.ts
@@ -60,6 +60,9 @@ const translators: TranslatorConfigObject = {
         }
       }
     }
+  },
+  'p': {
+    surroundingNewlines: 1
   }
 }
 


### PR DESCRIPTION
By default 2 newlines are added when a para is converted from html to markdown. Reducing it to 1