### PR TITLE
APP-5508: Remove extra linebreaks around divs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/src/translators.ts
+++ b/src/translators.ts
@@ -63,6 +63,9 @@ const translators: TranslatorConfigObject = {
   },
   'p': {
     surroundingNewlines: 1
+  },
+  'div': {
+    surroundingNewlines: 1
   }
 }
 


### PR DESCRIPTION
When processing emails, this package was adding extra linebreaks around divs. This is similar to this [issue](https://github.com/clearfeed/html-to-mrkdwn-ts/pull/18)