### PR TITLE
APP-6441 Add translators for Table tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { NodeHtmlMarkdown, NodeHtmlMarkdownOptions } from '@clearfeed-ai/node-html-markdown'
-import translators from './translators'
+import { NodeHtmlMarkdown, NodeHtmlMarkdownOptions, TranslatorConfigObject } from '@clearfeed-ai/node-html-markdown'
+import baseTranslators from './translators'
 import { findFirstImageSrc } from './utils'
 
 const baseOptions: Partial<NodeHtmlMarkdownOptions> = {
@@ -21,8 +21,17 @@ const baseOptions: Partial<NodeHtmlMarkdownOptions> = {
   lineStartEscape: [] as any
 }
 
-const htmlToMrkdwn = (html: string, options: Partial<NodeHtmlMarkdownOptions> = {}) => {
-  const result = NodeHtmlMarkdown.translate(html, { ...baseOptions, ...options }, translators)
+const htmlToMrkdwn = (
+  html: string,
+  options: Partial<NodeHtmlMarkdownOptions> = {},
+  translators: TranslatorConfigObject = {}
+) => {
+  const result = NodeHtmlMarkdown.translate(
+    html, 
+    { ...baseOptions, ...options },
+    { ...baseTranslators, ...translators }
+  );
+
   return {
     text: result,
     image: findFirstImageSrc(html)

--- a/src/translators.ts
+++ b/src/translators.ts
@@ -66,19 +66,7 @@ const translators: TranslatorConfigObject = {
   },
   'div': {
     surroundingNewlines: 1
-  },
-  'table': {
-        surroundingNewlines: 1
-    },
-    'tr': {
-        surroundingNewlines: 1
-    },
-    'th,td': {
-        surroundingNewlines: false
-    },
-    'caption': {
-        surroundingNewlines: 1
-    }
+  }
 }
 
 export default translators

--- a/src/translators.ts
+++ b/src/translators.ts
@@ -66,7 +66,19 @@ const translators: TranslatorConfigObject = {
   },
   'div': {
     surroundingNewlines: 1
-  }
+  },
+  'table': {
+        surroundingNewlines: 1
+    },
+    'tr': {
+        surroundingNewlines: 1
+    },
+    'th,td': {
+        surroundingNewlines: false
+    },
+    'caption': {
+        surroundingNewlines: 1
+    }
 }
 
 export default translators


### PR DESCRIPTION
More context - https://clearfeed.slack.com/archives/C02RX64MPK2/p1741110294597119?thread_ts=1740749890.303899&cid=C02RX64MPK2

## Changes Made

Allow receiving the translators in the `htmlToMrkdwn` function.

## Tested By

Tested for different tables:
- The formatting issue faced by the customer:
  - HTML:
    <img width="912" alt="Screenshot 2025-03-05 at 1 22 56 AM" src="https://github.com/user-attachments/assets/d3592314-2ac5-4ddb-b042-e241cacda133" />
  - Before v/s After the changes of the PR:
    <img width="873" alt="Screenshot 2025-03-05 at 12 44 05 AM" src="https://github.com/user-attachments/assets/2ac468c0-1296-49fc-8031-3c9718dfc849" />


- A normal table:
  - HTML:
  <img width="912" alt="Screenshot 2025-03-05 at 1 24 43 AM" src="https://github.com/user-attachments/assets/a8a35493-24d1-4a96-9893-e56d112dcdd3" />

  - Before v/s After the changes of the PR:
  <img width="873" alt="Screenshot 2025-03-05 at 1 09 19 AM" src="https://github.com/user-attachments/assets/6846c10d-33fd-4c6e-ad19-31fb4377bf13" />
  <img width="873" alt="Screenshot 2025-03-05 at 1 09 31 AM" src="https://github.com/user-attachments/assets/2892344f-a25d-4425-856f-75a936292934" />


