### PR TITLE
APP-7233 Fix texts containing underscores being removed 

### DIFF
--- a/__tests__/html-to-mrkdwn.spec.ts
+++ b/__tests__/html-to-mrkdwn.spec.ts
@@ -18,4 +18,13 @@ describe('Transform HTML to Slack mrdkwn', () => {
       text: '*Bold Text*'
     })
   })
+
+  it('When text contains underscores we need to preserve the input underscores ', () => {
+    const html = ` <div dir="auto"><i>hello_dark_ness</i></div>`
+    const actual = htmlToMrkdwn(html)
+    expect(actual).toEqual({
+      image: '',
+      text: '_hello_dark_ness_'
+    })
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,13 @@ const baseOptions: Partial<NodeHtmlMarkdownOptions> = {
 
   strongDelimiter: '*',
   strikeDelimiter: '~',
-  globalEscape: [] as any,
+
+  /**
+   * Escape underscores in the text as using underscores in words is common example -> this_is_a_word
+   * in NodeHtmlMarkdown we usually escape nested tags and as underscores is used for italic text we remove nested underscores
+   * to avoid this we escape underscores in the text
+   */
+  globalEscape: [/_/gm, '\\$&'] as any,
   lineStartEscape: [] as any
 }
 
@@ -31,9 +37,15 @@ const htmlToMrkdwn = (
     { ...baseOptions, ...options },
     { ...baseTranslators, ...translators }
   );
+  
+
+  /**
+   * As we escape underscores in the text we need to unescape them in the result
+   */
+  const unescapedResult = result.replace(/\\_/g, '_');
 
   return {
-    text: result,
+    text: unescapedResult,
     image: findFirstImageSrc(html)
   }
 }


### PR DESCRIPTION
we have a customer facing an issue where their italic texts containing underscores are not being formatted correctly
what happens is texts like `this_has_underscores` converts to `thishasunderscores` this is because
of 2 reasons
we override the existing options for globalEscape [here](https://github.com/clearfeed/html-to-mrkdwn-ts/blob/5dc406319a5912f9186657b8be97a3598f1aafdc/src/index.ts#L20)
which does not escape the underscores what then happens is in tag surround there is a regex to remove nested tags [here](https://github.com/clearfeed/node-html-markdown/blob/c7e31faa696d7384f06b5189e15bd275ae824ca0/src/utilities.ts#L55)  as italics are represented by _ it removes the underscores and thus the above result
we now have `globalEscape: [/_/gm, '\\$&']` which will escape only underscores
this regex is copied from [here](https://github.com/clearfeed/node-html-markdown/blob/c318667334d979db3cf7bcd3600f9dd1618ba5b3/src/config.ts#L54) and edited as per our use case 
and then when returning the result we again replace the escaped chars

###Screen shots
### zendesk
![Screenshot 2025-05-14 at 12 05 09 PM](https://github.com/user-attachments/assets/4412e5e6-b7dc-4cb3-98f5-3b8ef9a201a4)

### backward sync to slack
![Screenshot 2025-05-14 at 12 05 17 PM](https://github.com/user-attachments/assets/6ef9184c-b9f1-40dd-8121-601a5e318b23)

### test report 
![Screenshot 2025-05-20 at 12 04 41 PM](https://github.com/user-attachments/assets/c5fa232a-a7ef-4bdc-9a14-b244b36735a7)

