### PR TITLE
APP-8643 Update package version for @clearfeed-ai/node-html-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@clearfeed-ai/node-html-markdown": "^1.4.1"
+    "@clearfeed-ai/node-html-markdown": "^1.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,10 +480,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@clearfeed-ai/node-html-markdown@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/node-html-markdown/-/node-html-markdown-1.4.1.tgz#cae96eca84ab7e7f38f51da945dfbcad45b7278e"
-  integrity sha512-L2TlOq2uNB4JiWw26daXRzyB6K4mbjmVBizRaKJnoV00bTuKVW4QGbomcH1XggHTr71Lu+GiMXmiMqBP7OxU4g==
+"@clearfeed-ai/node-html-markdown@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/node-html-markdown/-/node-html-markdown-1.4.2.tgz#bb2a8b330a55d7ec53fb5cec8e6daaa4815b4426"
+  integrity sha512-1RTfsKyflormPhdreVk7GGxPZFHplNGCt+MPvfXRnqAI/rXMLUPoDoiIMLqxVD0sQXJNQwirCgLheczxzT2XHQ==
   dependencies:
     node-html-parser "^6.1.1"
 


### PR DESCRIPTION
update package version for:
@clearfeed-ai/node-html-markdown

https://github.com/clearfeed/node-html-markdown/pull/16
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bump @clearfeed-ai/node-html-markdown from ^1.4.1 to ^1.4.2 to pull in upstream fixes and improvements. Aligns with APP-8643 by keeping our HTML-to-Markdown conversion library up to date.

<!-- End of auto-generated description by cubic. -->

