### PR TITLE
APP-8644 bump up html package…1.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
@@ -43,6 +43,6 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@clearfeed-ai/node-html-markdown": "^1.4.2"
+    "@clearfeed-ai/node-html-markdown": "^1.4.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,10 +480,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@clearfeed-ai/node-html-markdown@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/node-html-markdown/-/node-html-markdown-1.4.2.tgz#bb2a8b330a55d7ec53fb5cec8e6daaa4815b4426"
-  integrity sha512-1RTfsKyflormPhdreVk7GGxPZFHplNGCt+MPvfXRnqAI/rXMLUPoDoiIMLqxVD0sQXJNQwirCgLheczxzT2XHQ==
+"@clearfeed-ai/node-html-markdown@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/node-html-markdown/-/node-html-markdown-1.4.3.tgz#dab91a4f24e9d548cc6a3abdc8c07130658f9494"
+  integrity sha512-Adk2JeccrxAyWBgpgmWWArSdNRJi0PqZl9SnZU8iu+MlblDbwvguauTCrgKHHWkLM1W06pPCmDcKc+6lV6MBjQ==
   dependencies:
     node-html-parser "^6.1.1"
 


### PR DESCRIPTION
bumping up html package and node package dependency
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped @clearfeed-ai/html-to-mrkdwn-ts to 2.2.6 and updated @clearfeed-ai/node-html-markdown to 1.4.3. Pulls in the latest upstream changes for HTML→mrkdwn conversion.

<!-- End of auto-generated description by cubic. -->

