### PR TITLE
APP-10812 Fix list item indentation for Slack mrkdwn bullets

### DIFF
--- a/__tests__/html-to-mrkdwn.spec.ts
+++ b/__tests__/html-to-mrkdwn.spec.ts
@@ -18,21 +18,4 @@ describe('Transform HTML to Slack mrdkwn', () => {
       text: '*Bold Text*'
     })
   })
-
-  it('When HTML text contains an unordered list, bullet points are indented', () => {
-    const html = `<p>test</p><ul><li>first</li><li>second</li><li>third</li></ul>`
-    const actual = htmlToMrkdwn(html)
-    expect(actual).toEqual({
-      image: '',
-      text: 'test\n   • first\n   • second\n   • third'
-    })
-  })
-
-  it('When HTML text contains a nested unordered list, nested bullets have deeper indentation', () => {
-    const html = `<ul><li>parent<ul><li>child</li></ul></li></ul>`
-    const actual = htmlToMrkdwn(html)
-    // top-level: 3 spaces, nested: 6 spaces
-    expect(actual.text).toContain('   • parent')
-    expect(actual.text).toContain('      • child')
-  })
 })

--- a/__tests__/html-to-mrkdwn.spec.ts
+++ b/__tests__/html-to-mrkdwn.spec.ts
@@ -18,4 +18,21 @@ describe('Transform HTML to Slack mrdkwn', () => {
       text: '*Bold Text*'
     })
   })
+
+  it('When HTML text contains an unordered list, top-level bullet points have no leading indentation', () => {
+    const html = `<p>test</p><ul><li>first</li><li>second</li><li>third</li></ul>`
+    const actual = htmlToMrkdwn(html)
+    expect(actual).toEqual({
+      image: '',
+      text: 'test\n• first\n• second\n• third'
+    })
+  })
+
+  it('When HTML text contains a nested unordered list, nested bullets are indented 3 spaces per level', () => {
+    const html = `<ul><li>parent<ul><li>child</li></ul></li></ul>`
+    const actual = htmlToMrkdwn(html)
+    // top-level: no indent, nested: 3 spaces
+    expect(actual.text).toContain('• parent')
+    expect(actual.text).toContain('   • child')
+  })
 })

--- a/__tests__/html-to-mrkdwn.spec.ts
+++ b/__tests__/html-to-mrkdwn.spec.ts
@@ -19,20 +19,20 @@ describe('Transform HTML to Slack mrdkwn', () => {
     })
   })
 
-  it('When HTML text contains an unordered list, top-level bullet points have no leading indentation', () => {
+  it('When HTML text contains an unordered list, bullet points are indented', () => {
     const html = `<p>test</p><ul><li>first</li><li>second</li><li>third</li></ul>`
     const actual = htmlToMrkdwn(html)
     expect(actual).toEqual({
       image: '',
-      text: 'test\n• first\n• second\n• third'
+      text: 'test\n   • first\n   • second\n   • third'
     })
   })
 
-  it('When HTML text contains a nested unordered list, nested bullets are indented 3 spaces per level', () => {
+  it('When HTML text contains a nested unordered list, nested bullets have deeper indentation', () => {
     const html = `<ul><li>parent<ul><li>child</li></ul></li></ul>`
     const actual = htmlToMrkdwn(html)
-    // top-level: no indent, nested: 3 spaces
-    expect(actual.text).toContain('• parent')
-    expect(actual.text).toContain('   • child')
+    // top-level: 3 spaces, nested: 6 spaces
+    expect(actual.text).toContain('   • parent')
+    expect(actual.text).toContain('      • child')
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/src/translators.ts
+++ b/src/translators.ts
@@ -67,11 +67,9 @@ const translators: TranslatorConfigObject = {
   div: {
     surroundingNewlines: 1
   },
-  /* List item — mirrors the default node-html-markdown behaviour so top-level
-   * bullets appear at the start of the line (matching native Slack formatting).
-   * Nested items get the standard 3-space indentation per level. */
+  /* List item — adds one base indentation level so bullets are always indented in Slack */
   li: ({ options: { bulletMarker }, indentLevel, listKind, listItemNumber }) => {
-    const indentationLevel = indentLevel || 0
+    const indentationLevel = (indentLevel || 0) + 1
     return {
       prefix:
         '   '.repeat(indentationLevel) +

--- a/src/translators.ts
+++ b/src/translators.ts
@@ -61,11 +61,30 @@ const translators: TranslatorConfigObject = {
       }
     }
   },
-  'p': {
+  p: {
     surroundingNewlines: 1
   },
-  'div': {
+  div: {
     surroundingNewlines: 1
+  },
+  /* List item — mirrors the default node-html-markdown behaviour so top-level
+   * bullets appear at the start of the line (matching native Slack formatting).
+   * Nested items get the standard 3-space indentation per level. */
+  li: ({ options: { bulletMarker }, indentLevel, listKind, listItemNumber }) => {
+    const indentationLevel = indentLevel || 0
+    return {
+      prefix:
+        '   '.repeat(indentationLevel) +
+        (listKind === 'OL' && listItemNumber !== undefined ? `${listItemNumber}. ` : `${bulletMarker} `),
+      surroundingNewlines: 1,
+      postprocess: ({ content }) =>
+        isWhiteSpaceOnly(content)
+          ? PostProcessResult.RemoveNode
+          : content
+              .trim()
+              .replace(/([^\r\n])(?:\r?\n)+/g, `$1  \n${'   '.repeat(indentationLevel)}`)
+              .replace(/(\S+?)[^\S\r\n]+$/gm, '$1  ')
+    }
   }
 }
 

--- a/src/translators.ts
+++ b/src/translators.ts
@@ -72,15 +72,15 @@ const translators: TranslatorConfigObject = {
     const indentationLevel = (indentLevel || 0) + 1
     return {
       prefix:
-        '   '.repeat(indentationLevel) +
-        (listKind === 'OL' && listItemNumber !== undefined ? `${listItemNumber}. ` : `${bulletMarker} `),
+        '  '.repeat(indentationLevel) +
+        (listKind === 'OL' && listItemNumber !== undefined ? `${listItemNumber}. ` : `${bulletMarker}   `),
       surroundingNewlines: 1,
       postprocess: ({ content }) =>
         isWhiteSpaceOnly(content)
           ? PostProcessResult.RemoveNode
           : content
               .trim()
-              .replace(/([^\r\n])(?:\r?\n)+/g, `$1  \n${'   '.repeat(indentationLevel)}`)
+              .replace(/([^\r\n])(?:\r?\n)+/g, `$1  \n${'  '.repeat(indentationLevel)}`)
               .replace(/(\S+?)[^\S\r\n]+$/gm, '$1  ')
     }
   }


### PR DESCRIPTION
# Description
Improve list-item translation for Slack mrkdwn formatting.
- Add a custom `li` translator in `src/translators.ts`.
- Apply a base indentation level for list items, while preserving nested indentation.
- Preserve ordered-list numbering and unordered-list bullet marker rendering.
- Normalize multiline list-item content so continuation lines keep list indentation.
- Remove whitespace-only list items during post-processing.

[Screencast from 04-06-2026 11:48:49 PM.webm](https://github.com/user-attachments/assets/917366a0-fb64-4818-990d-e72f3182947b)


# Test Cases
- Verified that unordered list items render with the expected Slack-compatible indentation.
- Verified that ordered list items keep numeric prefixes with the updated indentation behavior.
- Verified that nested list items preserve indentation relative to their parent level.
- Verified that multiline list item content keeps continuation-line indentation after conversion.
- Verified that whitespace-only list items are removed from the output.