### PR TITLE
APP-0000: CVE-2026-33672 picomatch vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2530,14 +2530,14 @@ picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
-  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pirates@^4.0.7:
   version "4.0.7"


### PR DESCRIPTION
## Description

picomatch had vulnerable versions 2.3.0 and 4.0.3 installed. Upgraded to 2.3.2 and 4.0.4.

CVE: https://github.com/clearfeed/html-to-mrkdwn-ts/security/dependabot/24


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patches `picomatch` to address CVE-2026-33672 by upgrading vulnerable versions to safe releases. Resolves the security alert with no code changes and bumps `@clearfeed-ai/html-to-mrkdwn-ts` to 2.2.8.

- **Dependencies**
  - Bump `picomatch` 2.x from 2.3.0 to 2.3.2
  - Bump `picomatch` 4.x from 4.0.3 to 4.0.4

<sup>Written for commit 85c04a2cc4118a3fd8ac112518537da285dc4433. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



