### PR TITLE
APP-0000: bump js-yaml to 3.15.0 to fix dependabot alert

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,9 +2039,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Fixes dependabot alert(s) for js-yaml quadratic-complexity DoS in merge key handling (medium severity).

- js-yaml `3.14.2` → `3.15.0` (alert #38)

Lockfile-only change, deps unchanged, verified with `yarn install --frozen-lockfile` — installs clean.

Jira: APP-0000

🤖 Generated with [Claude Code](https://claude.com/claude-code)