### PR TITLE
APP-12077 Fix unbalanced bold delimiter on headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 lib
+.omc/
+.vscode/

--- a/__tests__/translators.spec.ts
+++ b/__tests__/translators.spec.ts
@@ -55,6 +55,61 @@ describe('translators', () => {
     })
   })
 
+  /**
+   * A nested bold tag is not the only way to hit a leading delimiter - a heading with no bold
+   * tag at all reaches it whenever its own text starts with one. `<h2>*Starred</h2>` used to
+   * produce unbalanced `**Starred*`.
+   */
+  it('translate headings whose text starts with the bold delimiter', () => {
+    const html = `<div><h2>*Starred</h2></div>`
+    const actual = htmlToMrkdwn(html)
+    expect(actual).toEqual({ image: '', text: '*Starred*' })
+  })
+
+  /**
+   * Delimiters elsewhere in a heading's text were already stripped before the leading-delimiter
+   * fix; these pin that down as unchanged.
+   */
+  it('translate headings with a delimiter elsewhere in the text', () => {
+    const html = `<div><h1>Trailing*</h1><h2>2 * 3 = 6</h2></div>`
+    const actual = htmlToMrkdwn(html)
+    expect(actual).toEqual({ image: '', text: '*Trailing*\n\n*2  3 = 6*' })
+  })
+
+  /**
+   * Slack renders headings as bold, so a heading whose content is itself bold has the same
+   * delimiter applied twice. These used to come out unbalanced (`**Heading2*`), which Slack
+   * cannot parse and therefore renders as literal asterisks.
+   */
+  it('translate headings containing bold text', () => {
+    const html = `<div><h1><strong>test1</strong></h1><h2><strong>test2</strong></h2><h3><strong>test3</strong></h3><h4><strong>test4</strong></h4><h5><strong>test5</strong></h5><h6><strong>test6</strong></h6></div>`
+    const actual = htmlToMrkdwn(html)
+    expect(actual).toEqual({
+      image: '',
+      text: '*test1*\n\n*test2*\n\n*test3*\n\n*test4*\n\n*test5*\n\n*test6*'
+    })
+  })
+
+  it('translate headings containing bold text via <b>', () => {
+    const html = `<div><h2><b>test2</b></h2></div>`
+    const actual = htmlToMrkdwn(html)
+    expect(actual).toEqual({ image: '', text: '*test2*' })
+  })
+
+  it('translate headings that are only partially bold', () => {
+    const html = `<div><h2>Plain <strong>Bold</strong></h2></div>`
+    const actual = htmlToMrkdwn(html)
+    expect(actual).toEqual({ image: '', text: '*Plain Bold*' })
+  })
+
+  it('translate a Zendesk comment with bold headings', () => {
+    const html = `<div class="zd-comment" dir="auto"><h1 style="margin-left: 0px;" dir="auto"><strong>Heading1&nbsp;</strong></h1>&nbsp;<br><h2 style="margin-left: 0px;" dir="auto"><strong>Heading2</strong></h2><h2 style="margin-left: 0px;" dir="auto">&nbsp;</h2><h3 style="margin-left: 0px;" dir="auto"><strong>Heading3</strong></h3>&nbsp;<br><h4 style="margin-left: 0px;" dir="auto"><strong>Heading4</strong></h4></div>`
+    const actual = htmlToMrkdwn(html)
+    expect(actual.text).toEqual('*Heading1* \n\n  \n*Heading2*\n\n*Heading3*\n\n  \n*Heading4*')
+    // Every delimiter must be balanced, otherwise Slack renders them literally
+    expect(actual.text.split('*').length - 1).toEqual(8)
+  })
+
   it('translate img', () => {
     const html = `<div><img src='foo.jpg' alt='foo' /></div>`
     const actual = htmlToMrkdwn(html)

--- a/__tests__/utils.spec.ts
+++ b/__tests__/utils.spec.ts
@@ -1,8 +1,46 @@
-import { findFirstImageSrc } from '../src/utils'
+import { findFirstImageSrc, tagSurround } from '../src/utils'
 
 it('findFirstImageSrc', () => {
   const firstImgUrl = 'https://foo.bar/images/first.png'
   const html = `<div><img src="${firstImgUrl}" /><img src="second.jpg" /></div>`
   const actual = findFirstImageSrc(html)
   expect(actual).toEqual(firstImgUrl)
+})
+
+describe('tagSurround', () => {
+  it('surrounds plain content', () => {
+    expect(tagSurround('Title', '*')).toEqual('*Title*')
+  })
+
+  it('moves leading/trailing space outside the delimiters', () => {
+    expect(tagSurround('  Title  ', '*')).toEqual(' *Title* ')
+  })
+
+  it('strips a nested delimiter that is not at position 0', () => {
+    expect(tagSurround('Title*', '*')).toEqual('*Title*')
+  })
+
+  /**
+   * Regression: a nested delimiter at position 0 used to survive, so content already
+   * wrapped by a same-delimiter tag was surrounded again into unbalanced `**Title*`.
+   */
+  it('strips a nested delimiter at position 0', () => {
+    expect(tagSurround('*Title*', '*')).toEqual('*Title*')
+  })
+
+  it('strips nested delimiters regardless of how many occur', () => {
+    expect(tagSurround('*a* and *b*', '*')).toEqual('*a and b*')
+  })
+
+  it('preserves an escaped delimiter', () => {
+    expect(tagSurround('\\*lit*', '*')).toEqual('*\\*lit*')
+  })
+
+  it('supports a multi-character delimiter', () => {
+    expect(tagSurround('**Title**', '**')).toEqual('**Title**')
+  })
+
+  it('does not surround content that is only whitespace', () => {
+    expect(tagSurround('   ', '*')).toEqual('   ')
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/html-to-mrkdwn-ts",
   "description": "Fast HTML to Slack flavored mrkdwn",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,10 +39,10 @@ export function splitSpecial(s: string) {
  * Surround tag content with delimiter (moving any leading/trailing space to outside the tag
  */
 export function tagSurround(content: string, surroundStr: string) {
-  // If un-escaped surroundStr already occurs, remove all instances
+  // If un-escaped surroundStr already occurs, remove all instances.
   const nestedSurroundStrIndex = content.indexOf(surroundStr)
   if (nestedSurroundStrIndex >= 0)
-    content = content.replace(new RegExp(`([^\\\\])\\${surroundStr.split('').join('\\')}`, 'gm'), '$1')
+    content = content.replace(new RegExp(`(?<!\\\\)\\${surroundStr.split('').join('\\')}`, 'gm'), '')
 
   const lines = splitSpecial(content)
   let res = ''


### PR DESCRIPTION
Bumps to **2.2.9**.

### What `tagSurround` does

Wraps a tag's text in a Slack mrkdwn delimiter (`*` bold, `_` italic, `~` strike): strips any unescaped delimiter already in the content, then adds exactly one pair — keeping surrounding whitespace outside, since Slack won't render `* text *` as bold. Headings go through it because Slack has no headings, so `<h1>`–`<h6>` become bold.

### Regex change

```diff
- `([^\\\\])\\${…}`  with '$1'   // consuming
+ `(?<!\\\\)\\${…}`   with ''    // lookbehind
```

`[^\\]` **consumes** a character — it needs a real non-backslash character before the delimiter. `(?<!\\)` is zero-width — it only requires that a backslash *isn't* there. They diverge where there is nothing there: index 0.

```
1. What the "before the star" part requires

- A — [^\\] is a character class. It says: there must be a character here, and it must not be a backslash.
- B — (?<!\\) is a negative lookbehind. It says: whatever is behind me must not be a backslash. It doesn't require anything to be there at all.

"Must be a non-backslash" and "must not be a backslash" sound identical, but they diverge whenever there's nothing there.

2. What ends up inside the match

- A matches two characters — the preceding char plus the star. '*Title*'.match(A) → ["e*"]. The e is part of the match.
- B matches one character — just the star. A lookbehind is zero-width; it inspects without consuming.

This changes the replacement you need. With A you must write '$1' to put the innocent neighbour back; replacing with '' deletes it:

'*Title*'.replace(A, '')     →  '*Titl'     // the 'e' is collateral damage
'*Title*'.replace(A, '$1')   →  '*Title'
'*Title*'.replace(B, '')     →  'Title'

3. Position 0

A needs a character before the star, so it can never match a star at the start of a string. B can.

'*'.match(A)   →  null
'*'.match(B)   →  ['*']

4. Adjacent stars

Because A consumes the preceding character, that character is no longer available to serve as the "before" for the next star — matches can't overlap. B has no such coupling, since it consumes nothing:

'***'.replace(A, '$1')  →  '**'      // only one star removed
'***'.replace(B, '')    →  ''        // all three

Note also that in A, [^\\] happily matches a star itself (a star isn't a backslash), so in ** the first star gets eaten as the "preceding character" — A can delete stars it was never meant to treat as delimiters.

Where they agree

Escaping works the same in both — that was the shared goal, and both hit it:

'\*keep\*'  →  '\*keep\*'    // untouched by A and by B
'x\*y*'     →  'x\*y'        // A ($1) and B both remove only the unescaped star


One footnote: the m flag on B does nothing here. m only changes the meaning of ^ and $, and this pattern has neither — it's harmless but not load-bearing.
```


### The breaking string

`<h2><strong>Title</strong></h2>`. Tags resolve inside-out, so `<strong>` hands `*Title*` to `<h2>`. The old regex couldn't match the star at index 0 (nothing to consume), so only the trailing one was stripped:

```
*Title*  →  *Title  →  wrap  →  **Title*   ← unbalanced, Slack shows literal asterisks
*Title*  →  Title   →  wrap  →  *Title*    ← lookbehind
```

Also fixes `<h2>*Starred</h2>`, where the heading text itself starts with a delimiter.

### Tests

13 new cases: index-0 stripping, escaped and multi-char delimiters, partially-bold headings, `h1`–`h6`, and a real Zendesk comment asserting a balanced delimiter count. 23/23 pass.

Zendesk:
<img width="519" height="374" alt="image" src="https://github.com/user-attachments/assets/48155e34-6560-4b4d-a7b1-b71b7a963a04" />
<img width="519" height="374" alt="image" src="https://github.com/user-attachments/assets/785f100f-6476-414c-82fc-97c658ee2909" />



Slack:
<img width="519" height="374" alt="image" src="https://github.com/user-attachments/assets/5095173f-1f34-4c70-ae09-dce7f6e19f12" />


Also gitignores `.omc/` and `.vscode/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)